### PR TITLE
WIP: Decouple snapshot/restore from Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ restore: ## Restore previous Vault state by restoring a Consul snapshot
 	cd tasks && ./restore
 
 .PHONY: creds
-creds: ## Shows the root token and unseal keys for the currently running Vault instance if available in the local cache
+creds: ## Shows the root token and unseal keys for the currently running Vault instance cached
 	cd tasks && ./creds
 
 .PHONY: status

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Vault Playground V1.0.0 Makefile
+# Vault Playground V2.0.0 Makefile
 
 # Help Helper matches comments at the start of the task block so make help gives users information about each task
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repo is meant to make it easier for developers, operators, and CI servers to work locally with a production-like Vault environment.
 The Makefile contained in this repository will allow users to spin up (by default) a Consul cluster with 3 nodes, and 2 Vault servers running
 in HA mode. It also provides helpers for snapshotting the state of the cluster and restoring it from a cached or passed in Consul snapshot.
+By overriding the default values for task environment variables you can also snapshot and restore to or from remote Vault clusters. 
+This is meant for convenience during development only; it's still considered a bad practice to automate the unsealing of a production Vault cluster.
 
 ## Use Cases
 
@@ -16,7 +18,7 @@ Besides letting developers test what would happen in the event of a partial or c
 developers to run their applications against a local Vault instance that is seeded with relevant local secrets. Because the data inside a Consul snapshot is
 encrypted, snapshot files could be committed into source control. The keys needed to unseal the Vault would still need to be passed out of band if the snapshot 
 contained any sensitive data. If it didn't then the initialization file could be committed as well. _This feature is meant to help with local secrets only, 
-it's a bad idea to commit real secrets into source control._
+it's still a bad idea to commit real secrets into source control EVEN WHEN THEY'RE ENCRYPTED._
 
 ### Failover Scenarios
 If you're an operator that's new to Vault and Consul you can use the Vault Playground to test various data center failure models and practice manual restoration.
@@ -33,7 +35,9 @@ for each batch of tests.
 ## Prerequisites
   - [Docker](https://www.docker.com/get-docker) - This uses Docker to run Vault and Consul in containers
   - Network access to the [Docker Hub](https://hub.docker.com/) - On first init this calls out to get official versions of [Consul](https://hub.docker.com/_/consul/) and [Vault](https://hub.docker.com/_/vault/) if Docker doesn't have them cached locally.
-
+  - [curl](https://curl.haxx.se/) A command line tool for making network requests, usually installed on most systems by default.
+  - [jq](https://stedolan.github.io/jq/) A lightweight command line tool for parsing JSON. Available on most systems and easy to install on others.
+  
 ## Getting Started
 
 1. Clone this repo to the directory of your choice
@@ -53,7 +57,7 @@ status                         Displays the current state of the vault-playgroun
 ## Talking To Vault
 
 This tool is meant to be run locally and make it easier to test and debug Vault workflows, so it _does not_ enable TLS. As a result
-you'll have to explicitly tell the Vault CLI to connect over HTTP. Fortunately Vault supports the `VAULT_ADDR` environment variable. 
+you'll have to explicitly tell the Vault CLI to connect over HTTP. Fortunately, Vault supports the `VAULT_ADDR` environment variable. 
 Just set it to `http://127.0.0.1:8200` and you should be all set. If you're using `docker exec` this environment variable has already
 been set inside the Vault instances.
 
@@ -81,13 +85,14 @@ vault status
 
 Make was used to provide a simple and portable interface, but all of the tasks in this repo have been written as (mostly) 
 self contained shell scripts that could be run independently of Make. The only interdependency between these scripts is 
-that restore calls init. Many of the tasks can have their behavior altered by environment variables.
+that restore will call init if it detects that it's pointed at a local Consul server. Many of the tasks can have their 
+behavior altered by environment variables.
 
 ### init
 
 **Environment**
   - `VP_AUTO_INIT` (true) If true, after launching Vault the script will also run init, cache the resulting keys, and automatically unseal Vault
-  - `VP_HA_MODE` (true) If true will spin up a second Vault server ready to run as a standby. Unless VP_AUTO_INIT is true this server will need to be manually unsealed to enter standby mode
+  - `VP_VAULT_CLUSTER_SIZE` (2) The script will launch this many Vault nodes clustered in HA mode.
   - `VP_CONSUL_CLUSTER_SIZE` (3) How many Consul servers do you need?
   - `VP_CONSUL_PORT` (8500) The port on your host machine where you can access Consul
   - `VP_VAULT_PORT` (8200) The port on your host machine where you can access Vault
@@ -96,22 +101,36 @@ This script creates a dedicated docker network (called `vp`) and spins up the co
 By default this also initializes and unseals Vault automatically so you can use it immediately. You can connect to Consul
 from [http://localhost:8500](http://localhost:8500) and communicate with Vault through Docker exec or the Vault CLI.
 
+If `VP_AUTO_INIT` is true, the script will cache the output of the initialize API call locally (`$HOME/.vault-playground/init_dumps`) in a file 
+named after the Docker ID of the main vault server. 
+
 ### snapshot
 
 **Environment**
   - `VP_SNAPSHOT_NAME` (timestamp of the form: `%Y-%m-%d-%H-%M-%S`) Snapshots are named using the ID of the active Vault instance concatenated with this value. 
-
+  - `VP_CONSUL_TARGET` - (`http://127.0.0.1:8500` The Docker node) The Consul server that should be snapshotted
+  - `VP_CONSUL_DATACENTER` - (dc1) The Consul data center that should be snapshotted, locally this will almost always be the default. 
+  
 This script creates a snapshot in the local cache (`$HOME/.vault-playground/snapshots`) that by default is named with a timestamp.
 Generate a custom named snapshot with an environment variable: `VP_SNAPSHOT_NAME=the-one-with-postgres-secrets make snapshot`
+
+In addition to snapshotting the local Docker Cluster, you can also point this script at a running external Consul server 
+to pull down and cache a local snapshot:
+
+```
+VP_CONSUL_TARGET=https://myconsul.biz:8500 VP_SNAPSHOT_NAME=myconsul-biz-12-31-2017 make snapshot
+```
 
 ### restore
 
 **Environment**
   - `VP_SNAPSHOT` (empty string) Path to the Consul snapshot to restore. If this is blank, restore will list all the snapshots in its cache (`$HOME/.vault-playground/snapshots`).
   - `VP_INIT_DUMP` (empty string) Path to a file containing the output of the Vault initialization command. If this file doesn't exist, restore will check it's cache (`$HOME/.vault-playground/init_dumps`) if it finds nothing it will still restore the snapshot, but leave Vault sealed.
+  - `VP_CONSUL_TARGET` - (`http://127.0.0.1:8500` The Docker node) The Consul server that the snapshot should be restored to
+  - `VP_VAULT_TARGETS` - (all running Vault Playground Vault containers) A space delimited list of Vault servers that should be contacted for unsealing if an init dump file was provided or existed in the cache.
 
 **Dependencies**
-  - `init` This script calls out to init, setting `VP_AUTO_INIT=false` to setup a clean cluster before running the restore 
+  - `init` If the `VP_CONSUL_TARGET` variable has not been overridden this script calls out to init, setting `VP_AUTO_INIT=false` so it can setup a clean cluster before running the restore.
   
 Unless a snapshot file is specified this script will list all snapshots in its cache and prompt the user to select one. 
 Once the snapshot is restored the script will attempt to locate a valid initialization dump file in its cache if one was 
@@ -122,7 +141,7 @@ snapshot will still be restored.
 ### creds
 
 This is a helper task that looks in the cache for any initialization dumps from the currently running Vault instance and
-outputs them to the screen. 
+outputs them to the screen, allowing the user to see both the root and unseal keys for the currently running Vault.
 
 ### destroy
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vault Playground V1.0.0
+# Vault Playground V2.0.0
 
 This repo is meant to make it easier for developers, operators, and CI servers to work locally with a production-like Vault environment.
 The Makefile contained in this repository will allow users to spin up (by default) a Consul cluster with 3 nodes, and 2 Vault servers running

--- a/tasks/creds
+++ b/tasks/creds
@@ -8,11 +8,21 @@
 
 vp_init_cache=$HOME/.vault-playground/init_dumps
 
+if [ ! $(command -v docker) ]; then
+  echo -e "\ndocker not found! It must be installed before proceeding\n"
+  exit 1
+fi
+
+if [ ! $(command -v jq) ]; then
+  echo -e "\njq not found! It must be installed before proceeding\n"
+  exit 1
+fi
+
 vault_short_id=$(docker ps -q -f name=vp-vault1)
-vault_init_dump_path=${vp_init_cache}/${vault_short_id}.txt
+vault_init_dump_path=${vp_init_cache}/${vault_short_id}.json
 if [ -e "${vault_init_dump_path}" ]; then
   echo "Found cached creds file: $vault_init_dump_path"
-  cat ${vault_init_dump_path}
+  jq . ${vault_init_dump_path}
 else
   echo "No cached initialization credentials could be found for the currently running vault instance, or no vault instance is running."
 fi

--- a/tasks/creds
+++ b/tasks/creds
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Vault Playground V1.0.0
+# Vault Playground V2.0.0
 #
 # This is a helper task that looks in the cache for any initialization dumps from the currently running Vault instance
 # and outputs them to the screen.

--- a/tasks/destroy
+++ b/tasks/destroy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Vault Playground V1.0.0 destroy
+# Vault Playground V2.0.0 destroy
 #
 # This script terminates and removes all containers deployed in the Vault Playground docker network (vp).
 #

--- a/tasks/destroy
+++ b/tasks/destroy
@@ -7,6 +7,11 @@
 
 vp_network_name=vp
 
+if [ ! $(command -v docker) ]; then
+  echo -e "\ndocker not found! It must be installed before proceeding: https://www.docker.com/get-docker\n"
+  exit 1
+fi
+
 containers_to_destroy=$(docker ps -qa --no-trunc -f network=${vp_network_name})
 
 if [ ${#containers_to_destroy} != 0 ]; then

--- a/tasks/init
+++ b/tasks/init
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Vault Playground V1.0.0 init
+# Vault Playground V2.0.0 init
 #
 # This script creates a dedicated docker network (called vp) and spins up the configured number of Vault and Consul servers.
 # By default this also initializes and unseals Vault automatically so you can use it immediately. You can connect to Consul

--- a/tasks/init
+++ b/tasks/init
@@ -12,17 +12,34 @@
 
 vp_init_cache=$HOME/.vault-playground/init_dumps
 vp_network_name=vp
+vp_vault_shares=5
+vp_vault_threshold=3
 
 # Environment variables needed by this script defaulted for local use
-: "${VP_AUTO_INIT:=true}" # If true, after launching Vault also runs init, caches the resulting keys, and automatically unseals Vault
-: "${VP_HA_MODE:=true}" # If true will spin up a second Vault server ready to run as a standby. Unless AUTO_INIT_VALUE is true this server will need to be manually unsealed to enter standby mode
+: "${VP_AUTO_INIT:=true}" # If true, after launching Vault also runs init, caches the resulting keys, and automatically unseals Vault.
+: "${VP_VAULT_CLUSTER_SIZE:=2}" # The script will launch this many Vault nodes clustered in HA mode.
 : "${VP_CONSUL_CLUSTER_SIZE:=3}" # How many Consul servers do you need?
-: "${VP_CONSUL_PORT:=8500}" # The port on your host machine where you can access Consul's web-ui
+: "${VP_CONSUL_PORT:=8500}" # The port on your host machine where you can access Consul's web-ui.
 : "${VP_VAULT_PORT:=8200}" # The port on your host machine where you can talk to the first vault container. Any HA Vault nodes will forward a random port number.
 
 if [ $(docker network ls -f name=${vp_network_name} -q) ]; then
   echo "Looks like there's currently some vault playground infrastructure running in Docker's $vp_network_name network, try running destroy first."
   exit 0
+fi
+
+if [ ! $(command -v docker) ]; then
+  echo -e "\ndocker not found! It must be installed before proceeding: https://www.docker.com/get-docker\n"
+  exit 1
+fi
+
+if [ ! $(command -v jq) ]; then
+  echo -e "\njq not found! It must be installed before proceeding: https://stedolan.github.io/jq/\n"
+  exit 1
+fi
+
+if [ ! $(command -v curl) ]; then
+  echo -e "\ncurl not found! It must be installed before proceeding: https://curl.haxx.se/\n"
+  exit 1
 fi
 
 mkdir -p ${vp_init_cache}
@@ -33,35 +50,43 @@ docker network create --driver bridge ${vp_network_name} 2>/dev/null || echo ""
 # Spin up consul to back vault and then spin up vault.
 docker run -d -p ${VP_CONSUL_PORT}:8500 --network ${vp_network_name} -e CONSUL_BIND_INTERFACE=eth0 --name vp-consul1 consul && docker run -d -p ${VP_VAULT_PORT}:8200 --cap-add=IPC_LOCK --network ${vp_network_name} --name vp-vault1 -e VAULT_ADDR=http://127.0.0.1:8200 -e 'VAULT_LOCAL_CONFIG={"backend": {"consul": {"path": "/vault/", "check_timeout": "5s", "max_parallel": "128", "address": "http://vp-consul1:8500", "cluster_addr": "http://vp-vault1:8200", "api_addr": "http://vp-vault1:8200"}}, "listener": { "tcp": { "address":"0.0.0.0:8200", "tls_disable":1}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' vault server
 
-if [ ${VP_HA_MODE} == "true" ]; then
-  # The initial sleep is to prevent race conditions where the first vault's DNS entry isn't ready in Docker yet
-  sleep 2s && docker run -d -P --cap-add=IPC_LOCK --network ${vp_network_name} --name vp-vault2 -e VAULT_ADDR=http://127.0.0.1:8200 -e 'VAULT_LOCAL_CONFIG={"backend": {"consul": {"path": "/vault/", "check_timeout": "5s", "max_parallel": "128", "address": "http://vp-consul1:8500", "cluster_addr": "http://vp-vault2:8200", "api_addr": "http://vp-vault2:8200"}}, "listener": { "tcp": { "address":"0.0.0.0:8200", "tls_disable":1}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' vault server
-fi
+# Launch the requested number of Vault servers
+for (( i=2; i<=$VP_VAULT_CLUSTER_SIZE; i++ ))
+do
+  if [ $(docker ps -q -f name=vp-vault${i}) ]; then
+    echo "Scaling Vault: Server #$i exists"
+  else
+    echo "Scaling Vault: Launching server #$i"
+    docker run -d -P --cap-add=IPC_LOCK --network ${vp_network_name} --name vp-vault2 -e VAULT_ADDR=http://127.0.0.1:8200 -e 'VAULT_LOCAL_CONFIG={"backend": {"consul": {"path": "/vault/", "check_timeout": "5s", "max_parallel": "128", "address": "'"http://vp-consul1:8500"'", "cluster_addr": "'"http://vp-vault$i:8200"'", "api_addr": "'"http://vp-vault$i:8200"'"}}, "listener": { "tcp": { "address":"0.0.0.0:8200", "tls_disable":1}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' vault server
+  fi
+done
 
 # Give vault a couple of seconds to start before initializing and unsealing
 # It's a bad idea to persist the unseal info locally and automate the unsealing of vault in production, in dev it's fine.
 if [ ${VP_AUTO_INIT} == "true" ]; then
+  sleep 3s
   short_vault_id=$(docker ps -q -f name=vp-vault1)
-  vault_init_dump_path=${vp_init_cache}/${short_vault_id}.txt
+  vault_init_dump_path=${vp_init_cache}/${short_vault_id}.json
 
-  sleep 2s && docker exec vp-vault1 vault init > ${vault_init_dump_path}
-  head -3 ${vault_init_dump_path} | sed 's/ //g' | awk -F: '{print $2}' | xargs -I % docker exec vp-vault1 vault unseal %
+  curl --request PUT  -H "Content-Type: application/json" -d "{\"secret_shares\":$vp_vault_shares, \"secret_threshold\":$vp_vault_threshold}" http://127.0.0.1:8200/v1/sys/init > ${vault_init_dump_path}
 
-  # If vault is in HA mode we should unseal that node too
-  if [ $(docker ps -q -f name=vp-vault2) ]; then
-    sleep 2s && head -3 ${vault_init_dump_path} | awk -F: '{print $2}' | xargs -I % docker exec vp-vault2 vault unseal %
-  fi
+  # Unseal all Vault instances
+  containers=$(docker ps --filter name=vp-vault | awk '{if(NR>1) print $NF}')
+  for container in ${containers}
+  do
+    jq -r '.keys[]' ${vault_init_dump_path} | xargs -I % docker exec ${container} vault unseal %
+  done
 
 fi
 
 # Launch the requested number of consul servers
-for (( i=1; i<=$VP_CONSUL_CLUSTER_SIZE; i++ ))
+for (( i=2; i<=$VP_CONSUL_CLUSTER_SIZE; i++ ))
 do
   if [ $(docker ps -q -f name=vp-consul${i}) ]; then
     echo "Scaling Consul: Server #$i exists"
   else
     echo "Scaling Consul: Launching server #$i"
-    docker run -d --name vp-consul${i} --network ${vp_network_name} -e CONSUL_BIND_INTERFACE=eth0 consul agent -dev -join=vp-consul1 server ${i} starts
+    docker run -d --name vp-consul${i} --network ${vp_network_name} -e CONSUL_BIND_INTERFACE=eth0 consul agent -dev -join=vp-consul1
   fi
 done
 
@@ -74,7 +99,8 @@ echo "Vault Status:"
 if [ ${VP_AUTO_INIT} == "true" ]; then
   docker exec vp-vault1 vault status
   echo "Vault Initialization information dumped to: ${vault_init_dump_path}"
-  grep Root ${vault_init_dump_path}
+  echo "Root Token:"
+  jq -r '.root_token' ${vault_init_dump_path}
 else
   echo "Auto initialization of Vault was disabled... no status to report."
 fi

--- a/tasks/purge
+++ b/tasks/purge
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Vault Playground V1.0.0 purge
+# Vault Playground V2.0.0 purge
 #
 # This script deletes all cached credentials and snapshots by removing the $HOME/.vault-playground directory
 #

--- a/tasks/restore
+++ b/tasks/restore
@@ -12,20 +12,42 @@
 vp_init_cache=$HOME/.vault-playground/init_dumps
 vp_snapshot_cache=$HOME/.vault-playground/snapshots
 vp_network_name=vp
+default_vault_target=http://127.0.0.1:8200
+default_consul_target=http://127.0.0.1:8500
 
+: "${VP_CONSUL_TARGET:=$default_consul_target}"
+: "${VP_VAULT_TARGETS:=}"
 : "${VP_SNAPSHOT:=}"
 : "${VP_INIT_DUMP:=}"
 
-if [ $(docker network ls -f name=${vp_network_name} -q) ]; then
-  echo "Looks like there's currently some vault playground infrastructure running in Docker's $vp_network_name network."
-  echo "Before running restore please run destroy. DO NOT RUN PURGE."
+vault_targets=(${VP_VAULT_TARGETS});
+
+if [ $(docker network ls -f name=${vp_network_name} -q) ] && [ ${VP_CONSUL_TARGET} == ${default_consul_target} ]; then
+  echo "Looks like you're trying to run a local restore but there's currently some Vault Playground infrastructure"
+  echo "running in Docker's $vp_network_name network. Before running restore please run destroy. DO NOT RUN PURGE."
+  echo "You can also restore to a remote Consul server by passing in VP_CONSUL_TARGET"
   exit 0
 fi
 
 if [ ! -d "${vp_snapshot_cache}" ] && [ ! ${VP_SNAPSHOT} ]; then
-  echo "No snapshots available in snapshot cache: $vp_snapshot_cache, or passed in via VAULT_PLAYGROUND_SNAPSHOT."
+  echo "No snapshots available in snapshot cache: $vp_snapshot_cache, or passed in via VP_SNAPSHOT."
   echo "Have you taken any snapshots?"
   exit 0
+fi
+
+if [ ! $(command -v docker) ]; then
+  echo -e "\ndocker not found! It must be installed before proceeding: https://www.docker.com/get-docker\n"
+  exit 1
+fi
+
+if [ ! $(command -v jq) ]; then
+  echo -e "\njq not found! It must be installed before proceeding: https://stedolan.github.io/jq/\n"
+  exit 1
+fi
+
+if [ ! $(command -v curl) ]; then
+  echo -e "\ncurl not found! It must be installed before proceeding: https://curl.haxx.se/\n"
+  exit 1
 fi
 
 declare snapshot_path
@@ -51,38 +73,49 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-VP_AUTO_INIT=false ${DIR}/init
+# Only initialize an environment if we're working locally and an external Consul node was not targeted
+if [ ${VP_CONSUL_TARGET} == ${default_consul_target} ]; then
+  VP_AUTO_INIT=false ${DIR}/init
+fi
 
-docker container cp ${snapshot_path} vp-consul1:/tmp/to_restore.snap
-docker exec vp-consul1 consul snapshot restore /tmp/to_restore.snap
+curl --request PUT --data-binary @${snapshot_path} ${VP_CONSUL_TARGET}/v1/snapshot
 
-declare snapshot_keys
+declare snapshot_init_dump
 
+# This short ID will be valid for local Docker inits only
 vault_short_id=$(basename ${snapshot_path} | cut -c1-12)
 
-if [ -e "${vp_init_cache}/${vault_short_id}.txt" ]; then
-  snapshot_keys=${vp_init_cache}/${vault_short_id}.txt
+if [ -e "${vp_init_cache}/${vault_short_id}.json" ]; then
+  snapshot_init_dump=${vp_init_cache}/${vault_short_id}.json
 elif [ ${VP_INIT_DUMP} ]; then
-  snapshot_keys=${VP_INIT_DUMP}
+  snapshot_init_dump=${VP_INIT_DUMP}
 else
   echo "A Vault initialization key dump was not passed in with VP_INIT_DUMP or found in the local cache $vp_init_cache"
   echo "Vault will need to be manually unsealed. Hope you've got the keys!"
 fi
 
-if [ ${snapshot_keys} ]; then
-  head -3 ${snapshot_keys} | sed 's/ //g' | awk -F: '{print $2}' | xargs -I % docker exec -e VAULT_ADDR=http://127.0.0.1:8200 vp-vault1 vault unseal %
 
-  # If vault is in HA mode we should unseal that node too
-  if [ $(docker ps -q -f name=vp-vault2) ]; then
-    sleep 2s && head -3 ${snapshot_keys} | awk -F: '{print $2}' | xargs -I % docker exec -e VAULT_ADDR=http://127.0.0.1:8200 vp-vault2 vault unseal %
+if [ ${snapshot_init_dump} ]; then
+  # If Vault targets were passed in then connect to each targets unseal API endpoint
+  # It's not recommended to use this auto unsealing behavior for any production Vault
+  if [ ${VP_VAULT_TARGETS} ]; then
+    for ((i=0; i<${#vault_targets[@]}; ++i)); do
+      jq -r '.keys[]' ${snapshot_init_dump} | xargs -I % curl --request PUT  -H "Content-Type: application/json" -d '{"key": "%"}' ${vault_targets[$i]}/v1/sys/unseal
+      curl ${vault_targets[$i]}/v1/sys/health
+    done
+  else
+    containers=$(docker ps --filter name=vp-vault | awk '{if(NR>1) print $NF}')
+    for container in ${containers}
+    do
+      jq -r '.keys[]' ${snapshot_init_dump} | xargs -I % docker exec ${container} vault unseal %
+    done
   fi
-
-  docker exec -e VAULT_ADDR=http://127.0.0.1:8200 vp-vault1 vault status
 
   # Establish a new base init dump based on previous init dump
   new_vault_short_id=$(docker ps -q -f name=vp-vault1)
-  new_init_dump_path=${vp_init_cache}/${new_vault_short_id}.txt
-  cp ${snapshot_keys} ${new_init_dump_path}
+  new_init_dump_path=${vp_init_cache}/${new_vault_short_id}.json
+  cp ${snapshot_init_dump} ${new_init_dump_path}
   echo "Vault Initialization information dumped to: $new_init_dump_path"
-  grep Root ${new_init_dump_path}
+  echo "Root Token:"
+  jq -r '.root_token' ${new_init_dump_path}
 fi

--- a/tasks/restore
+++ b/tasks/restore
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Vault Playground V1.0.0 restore
+# Vault Playground V2.0.0 restore
 #
 # Unless a snapshot file is specified this script will list all snapshots in its cache and prompt the user to select one.
 # Once the snapshot is restored the script will attempt to locate a valid initialization dump file in its cache if one

--- a/tasks/snapshot
+++ b/tasks/snapshot
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Vault Playground V1.0.0 snapshot
+# Vault Playground V2.0.0 snapshot
 #
 # This script creates a snapshot in the local cache ($HOME/.vault-playground/snapshots) that by default is named with a
 # timestamp but also supports vanity naming via an environment variable

--- a/tasks/snapshot
+++ b/tasks/snapshot
@@ -6,21 +6,44 @@
 # timestamp but also supports vanity naming via an environment variable
 #
 
+declare short_vault_id
+
 vp_snapshot_cache=$HOME/.vault-playground/snapshots
 vp_network_name=vp
 timestamp=$(date +%Y-%m-%d-%H-%M-%S)
+default_consul_target=http://127.0.0.1:8500
 
 : "${VP_SNAPSHOT_NAME:=$timestamp}"
+: "${VP_CONSUL_TARGET:=$default_consul_target}"
+: "${VP_CONSUL_DATACENTER:=dc1}"
 
-if [ ! $(docker network ls -f name=${vp_network_name} -q) ]; then
-  echo "There is nothing running to snapshot. Have you initialized an environment with init?"
+if [ ! $(command -v docker) ]; then
+  echo -e "\ndocker not found! It must be installed before proceeding: https://www.docker.com/get-docker\n"
+  exit 1
+fi
+
+if [ ! $(command -v curl) ]; then
+  echo -e "\ncurl not found! It must be installed before proceeding: https://curl.haxx.se/\n"
+  exit 1
+fi
+
+
+# Make sure we can access Consul
+if [ $(curl -s -o /dev/null -w "%{http_code}" ${VP_CONSUL_TARGET}/v1/health/service/consul) != 200 ]; then
+  echo "Can't access Consul at $VP_CONSUL_TARGET, nothing to snapshot."
   exit 0
 fi
 
 mkdir -p ${vp_snapshot_cache}
 
-short_vault_id=$(docker ps -q -f name=vp-vault1)
-snap_name=${short_vault_id}-${VP_SNAPSHOT_NAME}.snap
+# If this is pointed at a local Docker instance it will prepend the snapshot with the instance id of vault so it can be auto restored.
+docker_vault_id=$(docker ps -q -f name=vp-vault1)
+if [ ${VP_CONSUL_TARGET} == ${default_consul_target} ] && [ ${docker_vault_id} ]; then
+  short_vault_id=${docker_vault_id}-
+fi
 
-docker exec vp-consul1 consul snapshot save /tmp/${snap_name} && echo "Wrote snapshot to $vp_snapshot_cache/$snap_name"
-docker container cp vp-consul1:/tmp/${snap_name} ${vp_snapshot_cache}
+snap_name=${short_vault_id}${VP_SNAPSHOT_NAME}.tgz
+
+curl ${VP_CONSUL_TARGET}/v1/snapshot?dc=${VP_CONSUL_DATACENTER} -o ${vp_snapshot_cache}/${snap_name}
+
+echo "Wrote snapshot to $vp_snapshot_cache/$snap_name"

--- a/tasks/status
+++ b/tasks/status
@@ -2,4 +2,9 @@
 
 vp_network_name=vp
 
+if [ ! $(command -v docker) ]; then
+  echo -e "\ndocker not found! It must be installed before proceeding: https://www.docker.com/get-docker\n"
+  exit 1
+fi
+
 docker ps -f network=$vp_network_name


### PR DESCRIPTION
Utilize API endpoints to make restoring/snapshoting live dev environments easier.

Ideally someone with access to a running dev cluster should be able to snapshot it:

```
VP_CONSUL_TARGET=http://1.1.1.1:8500 make snapshot
```
and then restore that snapshot locally for experimentation:

```
make restore
```

Still need to update documentation before merging