### PR TITLE
Restore Bug

### DIFF
--- a/tasks/init
+++ b/tasks/init
@@ -43,19 +43,38 @@ fi
 mkdir -p ${vp_init_cache}
 
 # Create Docker network for testing
-docker network create --driver bridge ${VP_NAMESPACE} 2>/dev/null || echo ""
+docker network create --driver bridge ${VP_NAMESPACE} >/dev/null 2>&1 || echo "Can't setup Docker network $VP_NAMESPACE"
 
+echo
+echo "Spin up initial Consul server:"
 # Spin up consul to back vault and then spin up vault.
-docker run -d -P --network ${VP_NAMESPACE} -e CONSUL_BIND_INTERFACE=eth0 --name ${VP_NAMESPACE}-consul1 consul && docker run -d -P --cap-add=IPC_LOCK --network ${VP_NAMESPACE} --name ${VP_NAMESPACE}-vault1 -e VAULT_ADDR=http://127.0.0.1:8200 -e 'VAULT_LOCAL_CONFIG={"backend": {"consul": {"path": "/vault/", "check_timeout": "5s", "max_parallel": "128", "address": "'"http://$VP_NAMESPACE-consul1:8500"'", "cluster_addr": "'"http://$VP_NAMESPACE-vault1:8200"'", "api_addr": "'"http://$VP_NAMESPACE-vault1:8200"'"}}, "listener": { "tcp": { "address":"0.0.0.0:8200", "tls_disable":1}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' vault server
+docker run -d -P --network ${VP_NAMESPACE} -e CONSUL_BIND_INTERFACE=eth0 --name ${VP_NAMESPACE}-consul1 consul
+echo
+
+sleep 2s
 
 # Launch the requested number of Vault servers
-for (( i=2; i<=$VP_VAULT_CLUSTER_SIZE; i++ ))
+for (( i=1; i<=$VP_VAULT_CLUSTER_SIZE; i++ ))
 do
+  echo "Spin up Vault server #$i"
   if [ $(docker ps -q -f name=${VP_NAMESPACE}-vault${i}) ]; then
-    echo "Scaling Vault: Server #$i exists"
+    echo "  Server #$i already exists"
   else
-    echo "Scaling Vault: Launching server #$i"
-    docker run -d -P --cap-add=IPC_LOCK --network ${VP_NAMESPACE} --name ${VP_NAMESPACE}-vault2 -e VAULT_ADDR=http://127.0.0.1:8200 -e 'VAULT_LOCAL_CONFIG={"backend": {"consul": {"path": "/vault/", "check_timeout": "5s", "max_parallel": "128", "address": "'"http://$VP_NAMESPACE-consul1:8500"'", "cluster_addr": "'"http://$VP_NAMESPACE-vault$i:8200"'", "api_addr": "'"http://$VP_NAMESPACE-vault$i:8200"'"}}, "listener": { "tcp": { "address":"0.0.0.0:8200", "tls_disable":1}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' vault server
+    docker run -d -P --cap-add=IPC_LOCK --network ${VP_NAMESPACE} --name ${VP_NAMESPACE}-vault${i} -e VAULT_ADDR=http://127.0.0.1:8200 -e 'VAULT_LOCAL_CONFIG={"backend": {"consul": {"path": "vault/", "check_timeout": "5s", "max_parallel": "128", "address": "'"http://$VP_NAMESPACE-consul1:8500"'", "cluster_addr": "'"http://$VP_NAMESPACE-vault$i:8200"'", "api_addr": "'"http://$VP_NAMESPACE-vault$i:8200"'"}}, "listener": { "tcp": { "address":"0.0.0.0:8200", "tls_disable":1}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' vault server
+    echo
+  fi
+done
+
+# Launch the requested number of consul servers
+for (( i=2; i<=$VP_CONSUL_CLUSTER_SIZE; i++ ))
+do
+  if [ $(docker ps -q -f name=${VP_NAMESPACE}-consul${i}) ]; then
+    echo "Scaling Consul: Server #$i exists"
+    echo
+  else
+    echo "Scaling Consul: Launching server #$i"
+    docker run -d -P --network ${VP_NAMESPACE} --name ${VP_NAMESPACE}-consul${i} consul agent -server -retry-join=${VP_NAMESPACE}-consul1 -client='0.0.0.0' -bind='{{ GetInterfaceIP "eth0" }}' -ui
+    echo
   fi
 done
 
@@ -68,7 +87,7 @@ if [ ${VP_AUTO_INIT} == "true" ]; then
 
   # Fetch the local port
   vp_vault1_local_port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8200/tcp") 0).HostPort}}' ${VP_NAMESPACE}-vault1)
-  curl --request PUT  -H "Content-Type: application/json" -d "{\"secret_shares\":$vp_vault_shares, \"secret_threshold\":$vp_vault_threshold}" http://127.0.0.1:${vp_vault1_local_port}/v1/sys/init > ${vault_init_dump_path}
+  curl --request PUT  -H "Content-Type: application/json" -d "{\"secret_shares\":$vp_vault_shares, \"secret_threshold\":$vp_vault_threshold}" http://127.0.0.1:${vp_vault1_local_port}/v1/sys/init > ${vault_init_dump_path} 2>/dev/null
 
   # Unseal all Vault instances
   containers=$(docker ps --filter name=${VP_NAMESPACE}-vault | awk '{if(NR>1) print $NF}')
@@ -79,25 +98,20 @@ if [ ${VP_AUTO_INIT} == "true" ]; then
 
 fi
 
-# Launch the requested number of consul servers
-for (( i=2; i<=$VP_CONSUL_CLUSTER_SIZE; i++ ))
-do
-  if [ $(docker ps -q -f name=${VP_NAMESPACE}-consul${i}) ]; then
-    echo "Scaling Consul: Server #$i exists"
-  else
-    echo "Scaling Consul: Launching server #$i"
-    docker run -d --name ${VP_NAMESPACE}-consul${i} --network ${VP_NAMESPACE} -e CONSUL_BIND_INTERFACE=eth0 consul agent -dev -join=${VP_NAMESPACE}-consul1
-  fi
-done
-
+echo
 echo "Vault Playground Test Environment Deployed"
-echo "Consul Status:"
-docker exec ${VP_NAMESPACE}-consul1 consul members
+echo
 
 echo "Vault Status:"
 
 if [ ${VP_AUTO_INIT} == "true" ]; then
-  docker exec ${VP_NAMESPACE}-vault1 vault status
+  for (( i=1; i<=$VP_VAULT_CLUSTER_SIZE; i++ ))
+  do
+    echo "Vault #$i"
+    docker exec ${VP_NAMESPACE}-vault${i} vault status
+    echo
+  done
+
   echo "Vault Initialization information dumped to: ${vault_init_dump_path}"
   echo "Root Token:"
   jq -r '.root_token' ${vault_init_dump_path}
@@ -105,7 +119,22 @@ else
   echo "Auto initialization of Vault was disabled... no status to report."
 fi
 
+echo
 echo "Vault is now running at:"
 docker ps -f name=${VP_NAMESPACE}-vault --format "{{.Names}}: http://{{printf \"%.13s\" .Ports}}"
 
+echo
+echo "Consul is running at:"
+
+for (( i=1; i<=${VP_CONSUL_CLUSTER_SIZE}; i++ ))
+do
+echo "http://127.0.0.1:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8500/tcp") 0).HostPort}}' ${VP_NAMESPACE}-consul${i})"
+done
+
+echo
+echo "Consul Status:"
+docker exec ${VP_NAMESPACE}-consul1 consul members
+
+echo
 echo "Set your host's VAULT_ADDR environment variable to communicate directly with it using the Vault CLI."
+echo

--- a/tasks/restore
+++ b/tasks/restore
@@ -13,16 +13,15 @@
 
 vp_init_cache=$HOME/.vault-playground/init_dumps
 vp_snapshot_cache=$HOME/.vault-playground/snapshots
-default_consul_target=http://127.0.0.1:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8500/tcp") 0).HostPort}}' ${VP_NAMESPACE}-consul1)
 
-: "${VP_CONSUL_TARGET:=$default_consul_target}"
+: "${VP_CONSUL_TARGET:=}"
 : "${VP_VAULT_TARGETS:=}"
 : "${VP_SNAPSHOT:=}"
 : "${VP_INIT_DUMP:=}"
 
 vault_targets=(${VP_VAULT_TARGETS});
 
-if [ $(docker network ls -f name=${VP_NAMESPACE} -q) ] && [ ${VP_CONSUL_TARGET} == ${default_consul_target} ]; then
+if [ -z "${VP_CONSUL_TARGET}" ] && [ $(docker network ls -f name=${VP_NAMESPACE} -q) ]; then
   echo "Looks like you're trying to run a local restore but there's currently some Vault Playground infrastructure"
   echo "running in Docker's $VP_NAMESPACE network. Before running restore please run destroy. DO NOT RUN PURGE."
   echo "You can also restore to a remote Consul server by passing in VP_CONSUL_TARGET"
@@ -52,7 +51,7 @@ fi
 
 declare snapshot_path
 
-if [ ${VP_SNAPSHOT} ]; then
+if [ -n "${VP_SNAPSHOT}" ]; then
   snapshot_path=${VP_SNAPSHOT}
 else
   options=(${vp_snapshot_cache}/*)
@@ -74,8 +73,9 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Only initialize an environment if we're working locally and an external Consul node was not targeted
-if [ ${VP_CONSUL_TARGET} == ${default_consul_target} ]; then
+if [ -z "${VP_CONSUL_TARGET}" ]; then
   VP_AUTO_INIT=false ${DIR}/init
+  VP_CONSUL_TARGET=http://127.0.0.1:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8500/tcp") 0).HostPort}}' ${VP_NAMESPACE}-consul1)
 fi
 
 curl --request PUT --data-binary @${snapshot_path} ${VP_CONSUL_TARGET}/v1/snapshot

--- a/tasks/snapshot
+++ b/tasks/snapshot
@@ -45,6 +45,6 @@ fi
 
 snap_name=${short_vault_id}${VP_SNAPSHOT_NAME}.tgz
 
-curl ${VP_CONSUL_TARGET}/v1/snapshot?dc=${VP_CONSUL_DATACENTER} -o ${vp_snapshot_cache}/${snap_name}
+curl ${VP_CONSUL_TARGET}/v1/snapshot?dc=${VP_CONSUL_DATACENTER} -o ${vp_snapshot_cache}/${snap_name} 2>/dev/null
 
 echo "Wrote snapshot to $vp_snapshot_cache/$snap_name"


### PR DESCRIPTION
Fix order of operations during restore.

There is still an occasional issue that is just a fact of life with restores where if the `core/lock` can't be invalidated in consul. This causes all vault instances even when unsealed to be in `standby` mode. This is a documented Vault behavior and we should be able to script a resolution.